### PR TITLE
Swap long and short entries based on signals

### DIFF
--- a/SMC_strategy.pine
+++ b/SMC_strategy.pine
@@ -920,13 +920,13 @@ if not inRange and exitOnOppositeSignals
 
 if inRange
     if longSignal
-        if exitOnOppositeSignals and strategy.position_size < 0
-            strategy.close('SHORT', comment = 'Opposite long signal', alert_message = 'SMC close short - opposite signal')
-        strategy.entry('LONG', strategy.long, alert_message = 'SMC long entry')
-    if shortSignal
         if exitOnOppositeSignals and strategy.position_size > 0
             strategy.close('LONG', comment = 'Opposite short signal', alert_message = 'SMC close long - opposite signal')
         strategy.entry('SHORT', strategy.short, alert_message = 'SMC short entry')
+    if shortSignal
+        if exitOnOppositeSignals and strategy.position_size < 0
+            strategy.close('SHORT', comment = 'Opposite long signal', alert_message = 'SMC close short - opposite signal')
+        strategy.entry('LONG', strategy.long, alert_message = 'SMC long entry')
 
 if strategy.position_size != 0
     avgPrice                   = strategy.position_avg_price


### PR DESCRIPTION
## Summary
- invert the order directions so long signals now open short trades and short signals open long trades
- adjust opposite-signal closing logic to match the inverted entries

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da3e27bf64832185a11e258381be5d